### PR TITLE
fixing the $_os bug while mass using

### DIFF
--- a/userAgent.php
+++ b/userAgent.php
@@ -193,7 +193,7 @@ class userAgent {
                 $_os[] = $this->mobile_ios[$os];
             break;
             default:
-                $_os = array_merge($this->android_os, $this->mobile_ios);
+                $_os = array_merge($this->android_os, array_values($this->mobile_ios));
         }
         // select random mobile os
         $selected_os = rtrim($_os[random_int(0, count($_os) - 1)], ';');


### PR DESCRIPTION
`PHP Notice:  Undefined offset: 3 in \home\....\userAgent.php on line 199`
`PHP Notice:  Undefined offset: 4 in \home\....\userAgent.php on line 199`
`PHP Notice:  Undefined offset: 5 in \home\....\userAgent.php on line 199`
$_os Variable at line #196 was defined like below :
`Array
(
    [0] => Linux; Android :androidVersion:; :androidDevice:
    [1] => Linux; U; Android :androidVersion:; :androidDevice:
    [2] => Android; Android :androidVersion:; :androidDevice:
    [iphone] => iPhone; CPU iPhone OS :number7-11:_:number0-9:_:number0-9:; like Mac OS X;
    [ipad] => iPad; CPU iPad OS :number7-11:_:number0-9:_:number0-9: like Mac OS X;
    [ipod] => iPod; CPU iPod OS :number7-11:_:number0-9:_:number0-9:; like Mac OS X;
)`
so by the proposed correction, the bug has fixed and all the array keys changed to Integer.